### PR TITLE
Select by field retrieve value

### DIFF
--- a/nuage_metroae_config/actions.py
+++ b/nuage_metroae_config/actions.py
@@ -9,6 +9,7 @@ from util import get_dict_field_no_case
 
 DEFAULT_SELECTION_FIELD = "name"
 FIRST_SELECTOR = "$first"
+LAST_SELECTOR = "$last"
 POSITION_SELECTOR = "$position"
 CHILD_SELECTOR = "$child"
 RETRIEVE_VALUE_SELECTOR = "$retrieve-value"
@@ -361,8 +362,7 @@ class CreateObjectAction(Action):
                                                        context)
             self.execute_children(writer, new_context)
         else:
-            if not self.is_store_only():
-                self.delete_object(writer, context)
+            self.delete_object(writer, context)
 
     def delete_object(self, writer, context=None):
         select_value = self.get_select_value()
@@ -378,6 +378,11 @@ class CreateObjectAction(Action):
 
                     new_context = context_list[0]
                 else:
+                    if isinstance(select_value, Action):
+                        if self.is_store_only():
+                            return
+                        select_value = select_value.get_stored_value()
+
                     new_context = writer.select_object(self.object_type,
                                                        self.select_by_field,
                                                        select_value,
@@ -386,16 +391,17 @@ class CreateObjectAction(Action):
                 # Always delete children first
                 self.execute_children(writer, new_context)
 
-                if not writer.is_validate_only():
-                    self.log.output(self._get_location("Revert "))
+                if not self.is_store_only():
+                    if not writer.is_validate_only():
+                        self.log.output(self._get_location("Revert "))
 
-                writer.delete_object(new_context)
+                    writer.delete_object(new_context)
             except MissingSelectionError:
                 # Skip deletion if object is not present (not created)
-                pass
+                self.log.debug("Selection failed for revert")
 
     def get_select_value(self):
-        return self.get_child_value(self.select_by_field)
+        return self.get_child_value(self.select_by_field.lower())
 
     def get_object_selector(self):
         if self.select_by_field.lower() == FIRST_SELECTOR:

--- a/tests/action_test_params.py
+++ b/tests/action_test_params.py
@@ -1032,6 +1032,38 @@ actions:
 """)
 
 
+CREATE_FIELD_RETRIEVE_VALUE = yaml.safe_load("""
+actions:
+- Create-object:
+    Type: Object1
+    Actions:
+    - Set-values:
+        name: L1-O1
+    - Create-object:
+        Type: Object2
+        Value: value_1
+        Actions:
+        - Set-values:
+            name: other_name
+        - Store-value:
+            As-name: object_id
+            From-field: objectId
+- Create-object:
+    Type: Object3
+    Select-By-field: other_id
+    Actions:
+    - Retrieve-value:
+        From-name: object_id
+        To-field: other_id
+    - Create-object:
+        Type: Level2
+        Actions:
+        - Set-values:
+            name: L2-O1
+
+""")
+
+
 SET_VALUES_DICT = yaml.safe_load("""
 actions:
 - Create-object:

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1021,7 +1021,8 @@ class TestActionsExecute(object):
         expected_actions = """
             start-session
             select-object Enterprise name = test_enterprise [None]
-            delete-object [context_1]
+            select-object Enterprise name = test_enterprise [None]
+            delete-object [context_2]
             stop-session
         """
 
@@ -1049,11 +1050,14 @@ class TestActionsExecute(object):
         expected_actions = """
             start-session
             select-object Enterprise name = test_enterprise [None]
+            select-object DomainTemplate name = template_test_domain [context_1]
+            get-value id [context_2]
+            select-object Domain name = test_domain [context_1]
             select-object Enterprise name = test_enterprise [None]
-            select-object Domain name = test_domain [context_2]
-            delete-object [context_3]
-            select-object DomainTemplate name = template_test_domain [context_2]
+            select-object Domain name = test_domain [context_4]
             delete-object [context_5]
+            select-object DomainTemplate name = template_test_domain [context_4]
+            delete-object [context_7]
             stop-session
         """
 
@@ -1090,13 +1094,15 @@ class TestActionsExecute(object):
             select-object Domain name = test_domain [context_1]
             select-object Subnet name = test_subnet [context_2]
             get-value id [context_3]
+            select-object IngressACLTemplate name = test_acl [context_2]
+            select-object EgressACLTemplate name = test_acl [context_2]
             select-object Enterprise name = test_enterprise [None]
-            select-object Domain name = test_domain [context_4]
-            select-object EgressACLTemplate name = test_acl [context_5]
-            delete-object [context_6]
-            select-object IngressACLTemplate name = test_acl [context_5]
+            select-object Domain name = test_domain [context_6]
+            select-object EgressACLTemplate name = test_acl [context_7]
             delete-object [context_8]
-            select-object Subnet name = test_subnet [context_5]
+            select-object IngressACLTemplate name = test_acl [context_7]
+            delete-object [context_10]
+            select-object Subnet name = test_subnet [context_7]
             stop-session
         """
 
@@ -1234,7 +1240,8 @@ class TestActionsExecute(object):
         expected_actions = """
             start-session
             select-object Enterprise field1 = value1 [None]
-            delete-object [context_1]
+            select-object Enterprise field1 = value1 [None]
+            delete-object [context_2]
             stop-session
         """
 
@@ -1283,13 +1290,18 @@ class TestActionsExecute(object):
         expected_actions = """
             start-session
             select-object Enterprise name = enterprise1 [None]
-            select-object Domain name = domain2 [context_1]
-            delete-object [context_2]
-            select-object Domain name = domain1 [context_1]
-            delete-object [context_4]
             select-object DomainTemplate name = domain_template [context_1]
+            get-value id [context_2]
+            select-object Domain name = domain1 [context_1]
+            select-object Domain name = domain2 [context_1]
+            select-object Enterprise name = enterprise1 [None]
+            select-object Domain name = domain2 [context_5]
             delete-object [context_6]
-            delete-object [context_1]
+            select-object Domain name = domain1 [context_5]
+            delete-object [context_8]
+            select-object DomainTemplate name = domain_template [context_5]
+            delete-object [context_10]
+            delete-object [context_5]
             stop-session
         """
 
@@ -1369,8 +1381,10 @@ class TestActionsExecute(object):
             start-session
             get-object-list Level1 [None]
             select-object Level2 name = L2-O1 [context_1]
-            delete-object [context_3]
-            delete-object [context_1]
+            get-object-list Level1 [None]
+            select-object Level2 name = L2-O1 [context_4]
+            delete-object [context_6]
+            delete-object [context_4]
             stop-session
         """
 
@@ -1383,8 +1397,10 @@ class TestActionsExecute(object):
             start-session
             get-object-list Level1 [None]
             select-object Level2 name = L2-O1 [context_2]
-            delete-object [context_3]
-            delete-object [context_2]
+            get-object-list Level1 [None]
+            select-object Level2 name = L2-O1 [context_5]
+            delete-object [context_6]
+            delete-object [context_5]
             stop-session
         """
 
@@ -1462,12 +1478,13 @@ class TestActionsExecute(object):
             start-session
             get-object-list Level1 [None]
             select-object Find name = L2-O2 [context_1]
+            select-object Level2 name = L2-O1 [context_1]
             select-object Find name = L2-O2 [context_1]
             get-object-list Level1 [None]
-            select-object Find name = L2-O2 [context_5]
-            select-object Find name = L2-O2 [context_5]
-            select-object Level2 name = L2-O1 [context_5]
-            delete-object [context_9]
+            select-object Find name = L2-O2 [context_6]
+            select-object Find name = L2-O2 [context_6]
+            select-object Level2 name = L2-O1 [context_6]
+            delete-object [context_10]
             stop-session
         """
 
@@ -1500,15 +1517,16 @@ class TestActionsExecute(object):
             select-object Find name = L3-O2 [context_3]
             get-object-list Level2 [context_1]
             select-object Find name = L3-O2 [context_6]
+            select-object Level3 name = L3-O1 [context_6]
             select-object Find name = L3-O2 [context_6]
             get-object-list Level1 [None]
-            get-object-list Level2 [context_10]
-            select-object Find name = L3-O2 [context_12]
-            get-object-list Level2 [context_10]
-            select-object Find name = L3-O2 [context_15]
-            select-object Find name = L3-O2 [context_15]
-            select-object Level3 name = L3-O1 [context_15]
-            delete-object [context_19]
+            get-object-list Level2 [context_11]
+            select-object Find name = L3-O2 [context_13]
+            get-object-list Level2 [context_11]
+            select-object Find name = L3-O2 [context_16]
+            select-object Find name = L3-O2 [context_16]
+            select-object Level3 name = L3-O1 [context_16]
+            delete-object [context_20]
             stop-session
         """
 
@@ -1540,13 +1558,13 @@ class TestActionsExecute(object):
             start-session
             get-object-list Level1 [None]
             select-object Find name = L2-O2 [context_1]
+            select-object Level2 name = L2-O1 [context_1]
             select-object Find name = L2-O2 [context_1]
             get-object-list Level1 [None]
-            select-object Find name = L2-O2 [context_5]
             select-object Find name = L2-O2 [context_6]
             select-object Find name = L2-O2 [context_6]
             select-object Level2 name = L2-O1 [context_6]
-            delete-object [context_9]
+            delete-object [context_10]
             stop-session
         """
 
@@ -1708,9 +1726,10 @@ class TestActionsExecute(object):
             select-object Object1 name = value_1 [None]
             get-value objectId [context_1]
             select-object Object2 id = value_1 [None]
+            select-object Level2 name = L2-O1 [context_2]
             select-object Object2 id = value_1 [None]
-            select-object Level2 name = L2-O1 [context_3]
-            delete-object [context_4]
+            select-object Level2 name = L2-O1 [context_4]
+            delete-object [context_5]
             select-object Object1 name = value_1 [None]
             stop-session
         """

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,7 +1,8 @@
 import os
 import pytest
 
-from action_test_params import (CREATE_OBJECTS_DICT,
+from action_test_params import (CREATE_FIELD_RETRIEVE_VALUE,
+                                CREATE_OBJECTS_DICT,
                                 CREATE_OBJECTS_NO_TYPE,
                                 CREATE_OBJECTS_SELECT_FIRST,
                                 CREATE_OBJECTS_SELECT_LAST,
@@ -1758,6 +1759,27 @@ class TestActionsExecute(object):
 
         assert "Action not retrieve-value" in str(e)
         assert "id" in str(e)
+
+    def test_create_field_retrieve__revert(self):
+
+        expected_actions = """
+            start-session
+            select-object Object1 name = L1-O1 [None]
+            select-object Object2 name = other_name [context_1]
+            get-value objectId [context_2]
+            select-object Object3 other_id = value_1 [None]
+            select-object Level2 name = L2-O1 [context_3]
+            delete-object [context_4]
+            delete-object [context_3]
+            select-object Object1 name = L1-O1 [None]
+            select-object Object2 name = other_name [context_7]
+            delete-object [context_8]
+            delete-object [context_7]
+            stop-session
+        """
+
+        self.run_execute_test(CREATE_FIELD_RETRIEVE_VALUE, expected_actions,
+                              is_revert=True)
 
     def test_save_to_file__success(self, capsys):
 


### PR DESCRIPTION
Allow ability for the config engine to revert via a retrieved value.  As a high-level overview like the following when doing a revert:

```
[select object1]
    [store id field as other_id]
[create object2 - use select-by-field: otherId]
    [retrieve other_id into field otherId]
```
The enhancement is to support a retrieve-value field for "select-by-field" when reverting a create-create object.
