### PR TITLE
Add consistent naming for underscores and dashes in metroae config args

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ MetroAE Config command-line tool usage:
                             Path containing template files. Can also set using
                             environment variable TEMPLATE_PATH
       --version             Displays version information
-      -sp SPEC_PATH, --spec-path SPEC_PATH
+      -sp SPEC_PATH, --spec_path SPEC_PATH
                             Path containing object specifications. Can also set
                             using environment variable VSD_SPECIFICATIONS_PATH
       -dp DATA_PATH, --data-path DATA_PATH

--- a/README.md
+++ b/README.md
@@ -189,11 +189,11 @@ MetroAE Config command-line tool usage:
       -sp SPEC_PATH, --spec_path SPEC_PATH
                             Path containing object specifications. Can also set
                             using environment variable VSD_SPECIFICATIONS_PATH
-      -dp DATA_PATH, --data-path DATA_PATH
+      -dp DATA_PATH, --data_path DATA_PATH
                             Path containing user data. Can also set using
                             environment variable USER_DATA_PATH
       -d DATA, --data DATA  Specify user data as key=value
-      -v VSD_URL, --vsd-url VSD_URL
+      -v VSD_URL, --vsd_url VSD_URL
                             URL to VSD REST API. Can also set using environment
                             variable VSD_URL
       -u USERNAME, --username USERNAME

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ MetroAE Config command-line tool usage:
 
     optional arguments:
       -h, --help            show this help message and exit
-      -tp TEMPLATE_PATH, --template-path TEMPLATE_PATH
+      -tp TEMPLATE_PATH, --template_path TEMPLATE_PATH
                             Path containing template files. Can also set using
                             environment variable TEMPLATE_PATH
       --version             Displays version information

--- a/config_dump.py
+++ b/config_dump.py
@@ -245,7 +245,7 @@ def parse_args():
                               ' set using environment variable %s') % (
                                   ENV_VSD_SPECIFICATIONS))
 
-    parser.add_argument('-v', '--vsd-url', dest='vsd_url',
+    parser.add_argument('-v', '--vsd_url', dest='vsd_url',
                         action='store', required=False,
                         default=os.getenv(ENV_VSD_URL, DEFAULT_URL),
                         help=('URL to VSD REST API. Can also set using '

--- a/config_dump.py
+++ b/config_dump.py
@@ -239,7 +239,7 @@ def compare_objects(superset_obj, subset_obj):
 def parse_args():
     parser = argparse.ArgumentParser(description=DESCRIPTION)
 
-    parser.add_argument('-sp', '--spec-path', dest='spec_path',
+    parser.add_argument('-sp', '--spec_path', dest='spec_path',
                         action='store', required=False,
                         help=('Path containing object specifications. Can also'
                               ' set using environment variable %s') % (

--- a/metroae_config.py
+++ b/metroae_config.py
@@ -188,14 +188,14 @@ def add_parser_arguments(parser):
     parser.add_argument('-sp', '--spec_path', dest='spec_path',
                         action='append', required=False,
                         help='Path containing object specifications. Can also set using environment variable %s' % (ENV_VSD_SPECIFICATIONS))
-    parser.add_argument('-dp', '--data-path', dest='data_path',
+    parser.add_argument('-dp', '--data_path', dest='data_path',
                         action='append', required=False,
                         default=None,
                         help='Path containing user data. Can also set using environment variable %s' % (ENV_USER_DATA))
     parser.add_argument('-d', '--data', dest='data',
                         action='append', required=False,
                         help='Specify user data as key=value')
-    parser.add_argument('-v', '--vsd-url', dest='vsd_url',
+    parser.add_argument('-v', '--vsd_url', dest='vsd_url',
                         action='store', required=False,
                         default=os.getenv(ENV_VSD_URL, DEFAULT_URL),
                         help='URL to VSD REST API. Can also set using environment variable %s' % (ENV_VSD_URL))
@@ -228,11 +228,11 @@ def add_parser_arguments(parser):
     parser.add_argument('--debug', dest='debug',
                         action='store_true', required=False,
                         help='Output in debug mode')
-    parser.add_argument('-lf', '--log-file', dest='log_file',
+    parser.add_argument('-lf', '--log_file', dest='log_file',
                         action='store', required=False,
                         default=os.getenv(ENV_LOG_FILE, ""),
                         help='Write logs to specified file. Can also set using environment variable %s' % (ENV_LOG_FILE))
-    parser.add_argument('-ll', '--log-level', dest='log_level',
+    parser.add_argument('-ll', '--log_level', dest='log_level',
                         action='store', required=False,
                         default=os.getenv(ENV_LOG_LEVEL, DEFAULT_LOG_LEVEL),
                         help='Specify log level (%s) Can also set using environment variable %s' % (", ".join(LOG_LEVEL_STRS), ENV_LOG_LEVEL))

--- a/metroae_config.py
+++ b/metroae_config.py
@@ -185,7 +185,7 @@ def add_template_parser_arguments(parser):
 
 def add_parser_arguments(parser):
     add_template_path_parser_argument(parser)
-    parser.add_argument('-sp', '--spec-path', dest='spec_path',
+    parser.add_argument('-sp', '--spec_path', dest='spec_path',
                         action='append', required=False,
                         help='Path containing object specifications. Can also set using environment variable %s' % (ENV_VSD_SPECIFICATIONS))
     parser.add_argument('-dp', '--data-path', dest='data_path',

--- a/metroae_config.py
+++ b/metroae_config.py
@@ -162,7 +162,7 @@ def get_parser():
 
 
 def add_template_path_parser_argument(parser):
-    parser.add_argument('-tp', '--template-path', dest='template_path',
+    parser.add_argument('-tp', '--template_path', dest='template_path',
                         action='append', required=False,
                         default=None,
                         help='Path containing template files. Can also set using environment variable %s' % (ENV_TEMPLATE))

--- a/template_helper.py
+++ b/template_helper.py
@@ -312,7 +312,7 @@ def parse_args():
     parser.add_argument('command_file', action='store',
                         help="File containing template creation commands.")
 
-    parser.add_argument('-sp', '--spec-path', dest='spec_path',
+    parser.add_argument('-sp', '--spec_path', dest='spec_path',
                         action='store', required=False,
                         default=os.getenv(ENV_VSD_SPECIFICATIONS,
                                           DEFAULT_VSD_SPECS),

--- a/update_examples.py
+++ b/update_examples.py
@@ -22,7 +22,7 @@ def parse_args():
                         help='Path containing template files. Can also set '
                              'using environment variable %s' % (ENV_TEMPLATE))
 
-    parser.add_argument('-sp', '--spec-path', dest='spec_path',
+    parser.add_argument('-sp', '--spec_path', dest='spec_path',
                         action='append', required=False,
                         default=os.getenv(ENV_VSD_SPECIFICATIONS, None),
                         help='Path containing object specifications. Can also'
@@ -138,7 +138,7 @@ def main():
         exit(1)
 
     if args.spec_path is None:
-        print("Please specify spec-path argument")
+        print("Please specify spec_path argument")
         exit(1)
 
     if args.software_version is None:

--- a/update_examples.py
+++ b/update_examples.py
@@ -16,7 +16,7 @@ EXAMPLE_COMMAND = "(example)$ metroae config create user-data.yml"
 def parse_args():
     parser = argparse.ArgumentParser(description=DESCRIPTION)
 
-    parser.add_argument('-tp', '--template-path', dest='template_path',
+    parser.add_argument('-tp', '--template_path', dest='template_path',
                         action='append', required=False,
                         default=os.getenv(ENV_TEMPLATE, None),
                         help='Path containing template files. Can also set '
@@ -134,7 +134,7 @@ def main():
     args = parse_args()
 
     if args.template_path is None:
-        print("Please specify template-path argument")
+        print("Please specify template_path argument")
         exit(1)
 
     if args.spec_path is None:


### PR DESCRIPTION
Add consistent naming for underscores and dashes in metroae config args in command prompt. MetroAE 1386
