### PR TITLE
Add order override for root select objects

### DIFF
--- a/nuage_metroae_config/actions.py
+++ b/nuage_metroae_config/actions.py
@@ -34,6 +34,7 @@ class Action(object):
         self.store_marks = set()
         self.retrieve_marks = set()
         self.template_name = None
+        self.order = 0
         if parent is None:
             self.level = 0
             self.log = Logger()
@@ -262,6 +263,23 @@ class Action(object):
             else:
                 self.parent.retrieve_marks.add(mark)
             self.parent.mark_ancestors_for_reorder(mark, is_store)
+
+    def reorder(self):
+        self.reorder_orders()
+        self.reorder_retrieve()
+
+    def reorder_orders(self):
+
+        sort_dict = dict()
+
+        for child in self.children:
+            if child.order not in sort_dict:
+                sort_dict[child.order] = list()
+            sort_dict[child.order].append(child)
+
+        self.children = list()
+        for order in sorted(sort_dict):
+            self.children.extend(sort_dict[order])
 
     def reorder_retrieve(self):
         complete = False
@@ -495,6 +513,10 @@ class SelectObjectAction(Action):
         updatable = Action.get_dict_field(select_dict, 'update-supported')
         if updatable is not None:
             self.is_updatable = updatable
+
+        order = Action.get_dict_field(select_dict, 'order')
+        if order is not None:
+            self.order = order
 
         if type(self.field) == list:
             if type(self.value) != list:

--- a/nuage_metroae_config/configuration.py
+++ b/nuage_metroae_config/configuration.py
@@ -173,7 +173,8 @@ class Configuration(object):
             self._walk_data(self._revert_data)
         else:
             self._walk_data(self._apply_data)
-        self.root_action.reorder_retrieve()
+        self.root_action.reorder()
+        self.log.debug(str(self.root_action))
         writer.start_session()
         self.root_action.execute(writer)
         writer.stop_session()

--- a/tests/action_test_params.py
+++ b/tests/action_test_params.py
@@ -569,6 +569,137 @@ actions:
 
 """)
 
+ORDER_OVERRIDE_1 = yaml.safe_load("""
+actions:
+- Select-object:
+    By-field: name
+    Type: Level1
+    Value: L1-O1
+    Actions:
+    - Select-object:
+        By-field: name
+        Type: Level2
+        Value: L2-O1
+        Actions:
+        - Store-value:
+            As-name: store_1
+            from-field: field1
+- Select-object:
+    By-field: name
+    Type: Level1
+    Value: L1-O2
+    Actions:
+    - Select-object:
+        By-field: name
+        Type: Level2
+        Value: L2-O2
+        Actions:
+        - Set-values:
+            name: L2-O2
+- Select-object:
+    By-field: name
+    Type: Level1
+    Value: L1-O3
+    Actions:
+    - select-object:
+        By-field: name
+        Type: Level2
+        Value: L2-O3
+        Actions:
+        - Retrieve-value:
+            From-name: store_1
+            To-field: field1
+""")
+
+ORDER_OVERRIDE_2 = yaml.safe_load("""
+actions:
+- Select-object:
+    By-field: name
+    Type: Level1
+    Value: L1-O4
+    Order: 1
+    Actions:
+    - Select-object:
+        By-field: name
+        Type: Level2
+        Value: L2-O4
+        Actions:
+        - Store-value:
+            As-name: store_2
+            from-field: field1
+- Select-object:
+    By-field: name
+    Type: Level1
+    Value: L1-O5
+    Order: 1
+    Actions:
+    - Select-object:
+        By-field: name
+        Type: Level2
+        Value: L2-O5
+        Actions:
+        - Set-values:
+            name: L2-O5
+- Select-object:
+    By-field: name
+    Type: Level1
+    Value: L1-O6
+    Order: 1
+    Actions:
+    - select-object:
+        By-field: name
+        Type: Level2
+        Value: L2-O6
+        Actions:
+        - Retrieve-value:
+            From-name: store_2
+            To-field: field1
+""")
+
+ORDER_OVERRIDE_3 = yaml.safe_load("""
+actions:
+- Select-object:
+    By-field: name
+    Type: Level1
+    Value: L1-O7
+    Order: 9
+    Actions:
+    - Select-object:
+        By-field: name
+        Type: Level2
+        Value: L2-O7
+        Actions:
+        - Store-value:
+            As-name: store_3
+            from-field: field1
+- Select-object:
+    By-field: name
+    Type: Level1
+    Value: L1-O8
+    Order: 9
+    Actions:
+    - Select-object:
+        By-field: name
+        Type: Level2
+        Value: L2-O8
+        Actions:
+        - Set-values:
+            name: L2-O8
+- Select-object:
+    By-field: name
+    Type: Level1
+    Value: L1-O9
+    Order: 9
+    Actions:
+    - select-object:
+        By-field: name
+        Type: Level2
+        Value: L2-O9
+        Actions:
+        - Retrieve-value:
+            From-name: store_3
+            To-field: field1
+""")
 
 RETRIEVE_AS_LIST = yaml.safe_load("""
 actions:

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -15,6 +15,9 @@ from action_test_params import (CREATE_FIELD_RETRIEVE_VALUE,
                                 ORDER_CREATE,
                                 ORDER_DISABLE_COMBINE_1,
                                 ORDER_DISABLE_COMBINE_2,
+                                ORDER_OVERRIDE_1,
+                                ORDER_OVERRIDE_2,
+                                ORDER_OVERRIDE_3,
                                 ORDER_MULTI_CREATE,
                                 ORDER_MULTI_SELECT_1,
                                 ORDER_MULTI_SELECT_2,
@@ -128,6 +131,14 @@ STORE_ORDERING_CASES = [
     (ORDER_STORE_3, ORDER_STORE_1, ORDER_STORE_2),
     (ORDER_STORE_2, ORDER_STORE_3, ORDER_STORE_1),
     (ORDER_STORE_3, ORDER_STORE_2, ORDER_STORE_1)]
+
+OVERRIDE_ORDERING_CASES = [
+    (ORDER_OVERRIDE_1, ORDER_OVERRIDE_2, ORDER_OVERRIDE_3),
+    (ORDER_OVERRIDE_1, ORDER_OVERRIDE_3, ORDER_OVERRIDE_2),
+    (ORDER_OVERRIDE_2, ORDER_OVERRIDE_1, ORDER_OVERRIDE_3),
+    (ORDER_OVERRIDE_3, ORDER_OVERRIDE_1, ORDER_OVERRIDE_2),
+    (ORDER_OVERRIDE_2, ORDER_OVERRIDE_3, ORDER_OVERRIDE_1),
+    (ORDER_OVERRIDE_3, ORDER_OVERRIDE_2, ORDER_OVERRIDE_1)]
 
 
 class TestActionsRead(object):
@@ -682,7 +693,7 @@ class TestActionsOrdering(object):
         for template in read_order:
             root_action.read_children_actions(template)
 
-        root_action.reorder_retrieve()
+        root_action.reorder()
 
         current_action = root_action.children[0]
         assert current_action.object_type == "Level1"
@@ -743,7 +754,7 @@ class TestActionsOrdering(object):
         for template in read_order:
             root_action.read_children_actions(template)
 
-        root_action.reorder_retrieve()
+        root_action.reorder()
 
         current_action = root_action.children[0]
         assert current_action.object_type == "Level1"
@@ -808,7 +819,7 @@ class TestActionsOrdering(object):
             for template in read_order:
                 root_action.read_children_actions(template)
 
-        root_action.reorder_retrieve()
+        root_action.reorder()
 
         assert "same object twice" in str(e)
         assert "Level1" in str(e)
@@ -823,7 +834,7 @@ class TestActionsOrdering(object):
             for template in read_order:
                 root_action.read_children_actions(template)
 
-        root_action.reorder_retrieve()
+        root_action.reorder()
 
         assert "already set" in str(e)
         assert "Level1" in str(e)
@@ -840,7 +851,7 @@ class TestActionsOrdering(object):
             root_action.reset_state()
             root_action.read_children_actions(template)
 
-        root_action.reorder_retrieve()
+        root_action.reorder()
 
         current_action = root_action.children[0]
         assert current_action.object_type == "Level1"
@@ -895,7 +906,7 @@ class TestActionsOrdering(object):
         root_action.reset_state()
         root_action.read_children_actions(ORDER_STORE_5)
 
-        root_action.reorder_retrieve()
+        root_action.reorder()
 
         current_action = root_action.children[0]
         assert current_action.object_type == "Level1"
@@ -928,7 +939,7 @@ class TestActionsOrdering(object):
 
         root_action.read_children_actions(ORDER_DISABLE_COMBINE_2)
 
-        root_action.reorder_retrieve()
+        root_action.reorder()
 
         current_action = root_action.children[0]
         assert current_action.object_type == "Level1"
@@ -946,6 +957,25 @@ class TestActionsOrdering(object):
         assert current_action.object_type == "Level1"
         assert current_action.field == "name"
         assert current_action.value == "L1-O1"
+
+    @pytest.mark.parametrize("read_order", OVERRIDE_ORDERING_CASES)
+    def test_override__success(self, read_order):
+        root_action = Action(None)
+
+        for template in read_order:
+            root_action.read_children_actions(template)
+
+        root_action.reorder_orders()
+
+        print str(root_action)
+
+        for i in range(9):
+
+            current_action = root_action.children[i]
+            assert current_action.value == "L1-O" + str(i + 1)
+
+            current_action = root_action.children[i].children[0]
+            assert current_action.value == "L2-O" + str(i + 1)
 
 
 class TestActionsExecute(object):

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -967,8 +967,6 @@ class TestActionsOrdering(object):
 
         root_action.reorder_orders()
 
-        print str(root_action)
-
         for i in range(9):
 
             current_action = root_action.children[i]


### PR DESCRIPTION
Add order override field to root level select actions.  The trees are reordered by increasing order field value.  Any action without order defined defaults to 0.  This allows some actions to be forced to the end of template processing when store/retrieve dependencies are insufficient.

```
  - select-object:
      type: Gateway
      by-field: name
      value: {{ gateway_name }}
      disable-combine: true
      order: 10
```