### PR TITLE
Skip save when only performing assignment on set-values

### DIFF
--- a/nuage_metroae_config/vsd_writer.py
+++ b/nuage_metroae_config/vsd_writer.py
@@ -398,7 +398,7 @@ class VsdWriter(DeviceWriterBase, DeviceReaderBase):
             raise SessionError("No object for setting values", location)
 
         try:
-            self._set_attributes(context.current_object, **kwargs)
+            is_changed = self._set_attributes(context.current_object, **kwargs)
             self._validate_values(context.current_object,
                                   skip_required_check=context.object_exists)
         except DeviceWriterError as e:
@@ -407,11 +407,15 @@ class VsdWriter(DeviceWriterBase, DeviceReaderBase):
         if context.object_exists:
             location = "Saving [%s]" % context
             self.log.debug(location)
-            if self.validate_only is False:
-                try:
-                    context.current_object.save()
-                except BambouHTTPError as e:
-                    raise VsdError(e, location)
+            if is_changed:
+                if self.validate_only is False:
+                    try:
+                        context.current_object.save()
+                    except BambouHTTPError as e:
+                        raise VsdError(e, location)
+            else:
+                self.log.debug("No change to existing object,"
+                               " save skipped [%s]" % context)
         else:
             location = "Creating child [%s]" % context
             self.log.debug(location)
@@ -719,11 +723,15 @@ class VsdWriter(DeviceWriterBase, DeviceReaderBase):
         return objects
 
     def _set_attributes(self, obj, **kwargs):
+        is_changed = False
         for field, value in kwargs.iteritems():
             local_name = field.lower()
             if not self._is_assign_attribute(local_name):
                 self._get_attribute_name(obj.spec, field)
                 setattr(obj, local_name, value)
+                is_changed = True
+
+        return is_changed
 
     def _get_attribute(self, obj, field):
         self._get_attribute_name(obj.spec, field)

--- a/tests/test_vsd_writer.py
+++ b/tests/test_vsd_writer.py
@@ -1484,6 +1484,59 @@ class TestVsdWriterSetValues(object):
     @pytest.mark.parametrize("validate_only", VALIDATE_ONLY_CASES)
     @patch("nuage_metroae_config.vsd_writer.ConfigObject")
     @patch("nuage_metroae_config.vsd_writer.Fetcher")
+    def test_assign_skip_save__success(self, mock_fetcher, mock_object,
+                                       validate_only):
+        vsd_writer = VsdWriter()
+        vsd_writer.set_validate_only(validate_only)
+        mock_session = setup_standard_session(vsd_writer)
+
+        mock_fetcher.return_value = mock_fetcher
+        mock_fetcher.get.return_value = []
+
+        child_object = MagicMock()
+        mock_object.return_value = child_object
+
+        if validate_only is True:
+            mock_session.root_object = MagicMock()
+            mock_session.root_object.spec = vsd_writer.specs['me']
+
+        mock_object = MagicMock()
+        mock_object.spec = vsd_writer.specs['enterprise']
+        mock_object.__resource_name__ = "enterprises"
+        mock_object.validate.return_value = True
+        mock_object.assign.return_value = True
+
+        context = Context()
+        context.parent_object = None
+        context.current_object = mock_object
+        context.object_exists = True
+
+        values = {
+            "assign(domain)": "abcd-1234"
+        }
+
+        new_context = vsd_writer.set_values(context, **values)
+
+        mock_object.validate.assert_called_once()
+
+        if validate_only is True:
+            mock_session.root_object.save.assert_not_called()
+            mock_object.assign.assert_not_called()
+        else:
+            mock_session.root_object.current_child_name == "enterprises"
+            mock_object.save.assert_not_called()
+            mock_object.assign.assert_called_once_with([child_object],
+                                                       nurest_object_type=None)
+            assert mock_object.current_child_name == "domains"
+            assert child_object.id == "abcd-1234"
+
+        assert new_context.parent_object is None
+        assert new_context.current_object == mock_object
+        assert new_context.object_exists is True
+
+    @pytest.mark.parametrize("validate_only", VALIDATE_ONLY_CASES)
+    @patch("nuage_metroae_config.vsd_writer.ConfigObject")
+    @patch("nuage_metroae_config.vsd_writer.Fetcher")
     def test_assign_multiple__success(self, mock_fetcher, mock_object,
                                       validate_only):
         vsd_writer = VsdWriter()


### PR DESCRIPTION
MetroAE Config always saves an object before an assign action is performed.

With some objects, e.g. system generated user groups, this causes a problem because the system generated group cannot be updated (i.e. saved) but can have users assigned to it.

To avoid this MetroAE Config should avoid trying to save objects if no fields are actually being changed (only assignments are occurring).