### PR TITLE
Add CSP root enterprise as a virtual object

### DIFF
--- a/metroae_config.py
+++ b/metroae_config.py
@@ -21,7 +21,7 @@ from nuage_metroae_config.vsd_writer import VsdWriter, SOFTWARE_TYPE
 # Disables annoying SSL certificate validation warnings
 urllib3.disable_warnings()
 
-ENGINE_VERSION = "1.0.1"
+ENGINE_VERSION = "1.1.0"
 
 PROG_NAME = "metroae config"
 DEFAULT_VSD_USERNAME = 'csproot'

--- a/nuage_metroae_config/actions.py
+++ b/nuage_metroae_config/actions.py
@@ -823,6 +823,11 @@ class SetValuesAction(Action):
                             not writer.does_object_exist(context)):
                         writer.set_values(context, **resolved_attributes)
                 else:
+                    if (self.parent.is_select() and
+                            not writer.is_validate_only()):
+                        self.log.output(self._get_location(
+                            "Unset %s " %
+                            str(self.parent.object_type)))
                     writer.unset_values(context, **resolved_attributes)
 
     def resolve_attributes(self):

--- a/nuage_metroae_config/vsd_writer.py
+++ b/nuage_metroae_config/vsd_writer.py
@@ -4,7 +4,8 @@ import re
 import requests
 
 from bambou.exceptions import BambouHTTPError
-from .bambou_adapter import ConfigObject, Fetcher, Root, Session
+from .bambou_adapter import (ConfigObject, EnterpriseFetcher, Fetcher, Root,
+                             Session)
 from .device_reader_base import DeviceReaderBase
 from .device_writer_base import DeviceWriterBase
 from .errors import (DeviceWriterError,
@@ -676,7 +677,10 @@ class VsdWriter(DeviceWriterBase, DeviceReaderBase):
 
         self._check_child_object(parent_object.spec, spec)
 
-        return Fetcher(parent_object, spec)
+        if spec["model"]["rest_name"] == "enterprise":
+            return EnterpriseFetcher(parent_object, spec)
+        else:
+            return Fetcher(parent_object, spec)
 
     def _add_object(self, obj, parent_object=None):
         if parent_object is None:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="nuage-metroae-config",
-    version="1.0.1",
+    version="1.1.0",
     author="Nuage Devops",
     author_email="devops@nuagenetworks.net",
     description="Template-based configuration tool for Nuage Networks VSD",

--- a/tests/test_vsd_writer.py
+++ b/tests/test_vsd_writer.py
@@ -601,7 +601,7 @@ class TestVsdWriterSelectObject(object):
 
     @pytest.mark.parametrize("validate_only", VALIDATE_ONLY_CASES)
     @patch("nuage_metroae_config.vsd_writer.ConfigObject")
-    @patch("nuage_metroae_config.vsd_writer.Fetcher")
+    @patch("nuage_metroae_config.vsd_writer.EnterpriseFetcher")
     def test_parent__success(self, mock_fetcher, mock_object, validate_only):
         vsd_writer = VsdWriter()
         vsd_writer.set_validate_only(validate_only)
@@ -710,7 +710,7 @@ class TestVsdWriterSelectObject(object):
         assert ("Select object BridgeInterface Name = test_child" in
                 e.value.get_display_string())
 
-    @patch("nuage_metroae_config.vsd_writer.Fetcher")
+    @patch("nuage_metroae_config.vsd_writer.EnterpriseFetcher")
     def test__not_found(self, mock_fetcher):
         vsd_writer = VsdWriter()
         mock_session = setup_standard_session(vsd_writer)
@@ -733,7 +733,7 @@ class TestVsdWriterSelectObject(object):
         assert ("Select object Enterprise Name = test_enterprise" in
                 e.value.get_display_string())
 
-    @patch("nuage_metroae_config.vsd_writer.Fetcher")
+    @patch("nuage_metroae_config.vsd_writer.EnterpriseFetcher")
     def test__multiple_found(self, mock_fetcher):
         vsd_writer = VsdWriter()
         mock_session = setup_standard_session(vsd_writer)
@@ -756,7 +756,7 @@ class TestVsdWriterSelectObject(object):
         assert ("Select object Enterprise Name = test_enterprise" in
                 e.value.get_display_string())
 
-    @patch("nuage_metroae_config.vsd_writer.Fetcher")
+    @patch("nuage_metroae_config.vsd_writer.EnterpriseFetcher")
     def test__bambou_error(self, mock_fetcher):
         vsd_writer = VsdWriter()
         mock_session = setup_standard_session(vsd_writer)
@@ -795,7 +795,7 @@ class TestVsdWriterGetObjectList(object):
 
     @pytest.mark.parametrize("validate_only", VALIDATE_ONLY_CASES)
     @patch("nuage_metroae_config.vsd_writer.ConfigObject")
-    @patch("nuage_metroae_config.vsd_writer.Fetcher")
+    @patch("nuage_metroae_config.vsd_writer.EnterpriseFetcher")
     def test_parent__success(self, mock_fetcher, mock_object, validate_only):
         vsd_writer = VsdWriter()
         vsd_writer.set_validate_only(validate_only)
@@ -902,7 +902,7 @@ class TestVsdWriterGetObjectList(object):
         assert ("Get object list BridgeInterface" in
                 e.value.get_display_string())
 
-    @patch("nuage_metroae_config.vsd_writer.Fetcher")
+    @patch("nuage_metroae_config.vsd_writer.EnterpriseFetcher")
     def test__not_found(self, mock_fetcher):
         vsd_writer = VsdWriter()
         mock_session = setup_standard_session(vsd_writer)
@@ -918,7 +918,7 @@ class TestVsdWriterGetObjectList(object):
 
         assert len(objects) == 0
 
-    @patch("nuage_metroae_config.vsd_writer.Fetcher")
+    @patch("nuage_metroae_config.vsd_writer.EnterpriseFetcher")
     def test__multiple_found(self, mock_fetcher):
         vsd_writer = VsdWriter()
         mock_session = setup_standard_session(vsd_writer)
@@ -941,7 +941,7 @@ class TestVsdWriterGetObjectList(object):
         assert objects[1].current_object == "enterprise_2"
         assert objects[1].object_exists is True
 
-    @patch("nuage_metroae_config.vsd_writer.Fetcher")
+    @patch("nuage_metroae_config.vsd_writer.EnterpriseFetcher")
     def test__bambou_error(self, mock_fetcher):
         vsd_writer = VsdWriter()
         mock_session = setup_standard_session(vsd_writer)


### PR DESCRIPTION
PASSES:
Python2 unit-tests
Python3 unit-tests (except for error from base64 in review #39 )
http://135.227.221.130:8080/job/gcp/job/INSTALL-GCP-SA-E2E/103/

Apparently, the "CSP" enterprise exists on the VSD but is not accessible in any way that I can find.  This is problematic since the config engine needs to be able to select it to use as a parent for a series of legitimate other objects nested underneath.  Given that we know its hard-coded id and name, I am making a change to the config engine to "virtually" be able to select it.  I am inserting in the bambou_adapter (our interface into VSPK) a check any time enterprises are fetched.  If the templates (or query tool) selects an enterprise by name "CSP" or by the hard-coded id, the engine will construct a suitable enterprise on its own without contacting the VSD.  This also happens if all enterprises are fetched, this special one is automatically appended to the list without contacting the VSD.

So what this does is trick the rest of the system into thinking that this special enterprise was successfully found, even though we just injected it in without help from the VSD.  It seems to work seamlessly.  I modified the group binding template to select the "CSP" enterprise and I was able to do the assignment without error.  I am also able to do queries with the query tool on objects under the CSP enterprise.  This "virtual" enterprise is only going to be available in the next engine version, so that is why I added the "1.1.0" engine version requirement for the template.