### PR TITLE
Fix the handling of unicode strings in validation

### DIFF
--- a/nuage_metroae_config/template.py
+++ b/nuage_metroae_config/template.py
@@ -3,6 +3,7 @@ import jinja2.ext
 import json
 import os
 import re
+import six
 import sys
 import yaml
 
@@ -498,8 +499,7 @@ class Template(object):
 
     def _validate_variable_value(self, var_schema, var_name, value, var_type):
         if var_type in JSON_SCHEMA_STRING_TYPES:
-            if isinstance(value, str) or (
-                    sys.version_info < (3,) and isinstance(value, unicode)):
+            if isinstance(value, six.string_types):
                 return True
             else:
                 allow_int = get_dict_field_no_case(var_schema, "allow-integer")
@@ -525,7 +525,7 @@ class Template(object):
             else:
                 self._raise_value_error(var_name, "is not a boolean")
         elif var_type == "choice":
-            if not isinstance(value, str):
+            if not isinstance(value, six.string_types):
                 self._raise_value_error(var_name, "is not a string")
             choices = self._get_required_field(var_schema, "choices")
             upper_choices = [x.upper() for x in choices]

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -479,6 +479,25 @@ class TestTemplateVariableValidation(object):
 
         assert template.validate_template_data(**all_vars) is True
 
+    def test_all_vars_unicode__success(self):
+        template = self.get_variables_template()
+
+        all_vars = {"name": u"test_name",
+                    "select_name": u"test_select",
+                    "int_as_string": 10,
+                    "number": 10,
+                    "floating_point": 0.2,
+                    "true_or_false": True,
+                    "ipv4_address": u"192.168.0.1",
+                    "ipv6_address": u"8000::0001",
+                    "any_ip_address": u"10.0.0.0",
+                    "fruit": u"Apple",
+                    "string_list": [u"a", u"b", u"c"],
+                    "int_list": [1, 2, 10],
+                    "soda_list": [u"coke", u"Pepsi", u"SPRITE"]}
+
+        assert template.validate_template_data(**all_vars) is True
+
     @pytest.mark.parametrize("data, message", INVALID_VALUES_CASES)
     def test__invalid(self, data, message):
         template = self.get_variables_template()


### PR DESCRIPTION
Tested with unit-tests in both Python2 and Python3